### PR TITLE
Use alphabet[0] instead of '1'.

### DIFF
--- a/lib/bs58.js
+++ b/lib/bs58.js
@@ -57,7 +57,7 @@ function decode (input) {
 
     num = num.multiply(base).add(BigInteger.valueOf(p));
 
-    if (char == '1' && !seen_other) {
+    if (char == alphabet[0] && !seen_other) {
       ++leading_zero;
     }
     else {


### PR DESCRIPTION
Line 34 replaces leading zeros with `alphabet[0]` so line 60 should perform the inverse operation. This is only an issue if `alphabet` is modified.
