### PR TITLE
Replace bigi with digit-array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+1.1.1 / 2014-06-27
+------------------
+* replaced `bigi` dep, implemented direct byte conversion
+
 1.1.0 / 2014-06-26
 ------------------
 * user `Buffer` internally for calculations, providing cleaner code and a performance increase. [Daniel Cousens](https://github.com/cryptocoinjs/bs58/commit/129c71de8bc1e36f113bce06da0616066f41c5ca)
-
 
 1.0.0 / 2014-05-27
 ------------------

--- a/lib/bs58.js
+++ b/lib/bs58.js
@@ -1,73 +1,94 @@
 // Base58 encoding/decoding
-// Originally written by Mike Hearn for BitcoinJ
-// Copyright (c) 2011 Google Inc
-// Ported to JavaScript by Stefan Thomas
-// Merged Buffer refactorings from base58-native by Stephen Pair
-// Copyright (c) 2013 BitPay Inc
 
-var assert = require('assert')
-var BigInteger = require('bigi')
+'use strict'
 
-var ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-var ALPHABET_BUF = new Buffer(ALPHABET, 'ascii')
-var ALPHABET_MAP = {}
-for(var i = 0; i < ALPHABET.length; i++) {
-  ALPHABET_MAP[ALPHABET.charAt(i)] = BigInteger.valueOf(i)
-}
-var BASE = new BigInteger('58')
+module.exports.decode = decode;
+module.exports.encode = encode;
 
-function encode(buffer) {
-  var bi = BigInteger.fromBuffer(buffer)
-  var result = new Buffer(buffer.length << 1)
+var ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+var INVERSE_ALPHABET = {};
+var BASE = 58;
 
-  var i = result.length - 1
-  while (bi.signum() > 0) {
-    var remainder = bi.mod(BASE)
-    bi = bi.divide(BASE)
+ALPHABET.split('').forEach(function(c, i){ INVERSE_ALPHABET[c] = i; });
 
-    result[i] = ALPHABET_BUF[remainder.intValue()]
-    i--
+/**
+ * Encodes a node Buffer as base58.
+ *
+ * @param {Buffer} input The buffer to encode.
+ *
+ * @return {string} The input encoded as base58.
+ */
+function encode (input) {
+  // Handle the edge case for empty input.
+  if(input.length == 0) return '';
+
+  // Convert from bytes to base58.
+  var digits = [0];
+  for (var i = 0; i < input.length; i++) {
+    for (var j = 0; j < digits.length; j++) { digits[j] <<= 8; }
+    digits[digits.length - 1] += input[i];
+
+    var carry = 0;
+    for (var j = digits.length - 1; j >= 0; j--){
+      digits[j] += carry;
+      carry = (digits[j] / BASE) | 0;
+      digits[j] %= BASE;
+    }
+
+    while (carry) {
+      digits.unshift(carry);
+      carry = (digits[0] / BASE) | 0;
+      digits[0] %= BASE;
+    }
   }
 
-  // deal with leading zeros
-  var j = 0
-  while (buffer[j] === 0) {
-    result[i] = ALPHABET_BUF[0]
-    j++
-    i--
-  }
+  // Preserve leading padding characters.
+  for (var i = 0; i < input.length - 1 && input[i] == 0; i++) { digits.unshift(0); }
 
-  return result.slice(i + 1, result.length).toString('ascii')
-}
-
-function decode(string) {
-  if (string.length === 0) return new Buffer(0)
-
-  var num = BigInteger.ZERO
-
-  for (var i = 0; i < string.length; i++) {
-    num = num.multiply(BASE)
-
-    var figure = ALPHABET_MAP[string.charAt(i)]
-    assert.notEqual(figure, undefined, 'Non-base58 character')
-
-    num = num.add(figure)
-  }
-
-  // deal with leading zeros
-  var j = 0
-  while ((j < string.length) && (string[j] === ALPHABET[0])) {
-    j++
-  }
-
-  var buffer = num.toBuffer()
-  var leadingZeros = new Buffer(j)
-  leadingZeros.fill(0)
-
-  return Buffer.concat([leadingZeros, buffer])
+  // Encode the digits with the base58 alphabet.
+  return digits.map(function(digit) { return ALPHABET[digit]; }).join('');
 }
 
-module.exports = {
-  encode: encode,
-  decode: decode
+/**
+ * Decodes a base58 string as a Buffer.
+ *
+ * @param {string} input The string to decode.
+ *
+ * @return {Buffer} The input decoded into a Buffer.
+ */
+function decode (input) {
+  // Handle the edge case for empty input.
+  if(input.length == 0) return new Buffer([]);
+
+  // Decode the base58 input.
+  input = input.split('').map(function(c){
+    if(typeof INVERSE_ALPHABET[c] === 'undefined') { throw('Non-base58 character'); }
+    return INVERSE_ALPHABET[c];
+  });
+
+  // Convert the base58 digits into a byte array.
+  var bytes = [0];
+  for (var i = 0; i < input.length; i++) {
+    for (var j = 0; j < bytes.length; j++) { bytes[j] *= BASE; }
+    bytes[bytes.length - 1] += input[i];
+
+    var carry = 0;
+    for (var j = bytes.length - 1; j >= 0; j--){
+      bytes[j] += carry;
+      carry = bytes[j] >> 8;
+      bytes[j] &= 0xff;
+    }
+    
+    while (carry) {
+      bytes.unshift(carry);
+      carry = bytes[0] >> 8;
+      bytes[0] &= 0xff;
+    }
+  }
+
+  // Preserve leading padding characters.
+  for (var i = 0; i < input.length - 1 && input[i] == 0; i++) { bytes.unshift(0); }
+
+  // Create a Buffer with the byte array.
+  return new Buffer(bytes);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs58",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Base 58 encoding / decoding",
   "keywords": [
     "base58",
@@ -26,9 +26,6 @@
     "type": "git"
   },
   "main": "./lib/bs58.js",
-  "dependencies": {
-    "bigi": "^1.1.0"
-  },
   "scripts": {
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --reporter list test/*.js",
     "coveralls": "npm run-script coverage && node ./node_modules/.bin/coveralls < coverage/lcov.info",


### PR DESCRIPTION
[`bigi`](https://github.com/cryptocoinjs/bigi) has a lot of code that is not needed for base conversion.
~~[`digit-array`](https://github.com/deckar01/digit-array) is a much lighter library that specializes in converting between arbitrary bases.~~

This change should also make encoding and decoding faster, because [`bigi`](https://github.com/cryptocoinjs/bigi) uses a large intermediate base internally.
~~[`digit-array`](https://github.com/deckar01/digit-array) performs direct base conversion, which should cut the conversion computation in half.~~

This PR replaces `bigi` with a small amount of pure JavaScript.

Fixes #2.
