### PR TITLE
Remove bigi dep, optimize byte operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+1.x.y / 2014-06-29
+------------------
+* removed `bigi` dep, implemented direct byte conversion
+
 1.1.0 / 2014-06-26
 ------------------
 * user `Buffer` internally for calculations, providing cleaner code and a performance increase. [Daniel Cousens](https://github.com/cryptocoinjs/bs58/commit/129c71de8bc1e36f113bce06da0616066f41c5ca)
-
 
 1.0.0 / 2014-05-27
 ------------------

--- a/lib/bs58.js
+++ b/lib/bs58.js
@@ -6,65 +6,73 @@
 // Copyright (c) 2013 BitPay Inc
 
 var assert = require('assert')
-var BigInteger = require('bigi')
 
 var ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-var ALPHABET_BUF = new Buffer(ALPHABET, 'ascii')
 var ALPHABET_MAP = {}
 for(var i = 0; i < ALPHABET.length; i++) {
-  ALPHABET_MAP[ALPHABET.charAt(i)] = BigInteger.valueOf(i)
+  ALPHABET_MAP[ALPHABET.charAt(i)] = i
 }
-var BASE = new BigInteger('58')
+var BASE = 58
 
 function encode(buffer) {
-  var bi = BigInteger.fromBuffer(buffer)
-  var result = new Buffer(buffer.length << 1)
+  if (buffer.length === 0) return ''
 
-  var i = result.length - 1
-  while (bi.signum() > 0) {
-    var remainder = bi.mod(BASE)
-    bi = bi.divide(BASE)
+  var i, j, digits = [0]
+  for (i = 0; i < buffer.length; i++) {
+    for (j = 0; j < digits.length; j++) digits[j] <<= 8
+    digits[digits.length - 1] += buffer[i]
 
-    result[i] = ALPHABET_BUF[remainder.intValue()]
-    i--
+    var carry = 0
+    for (j = digits.length - 1; j >= 0; j--){
+      digits[j] += carry
+      carry = (digits[j] / BASE) | 0
+      digits[j] %= BASE
+    }
+
+    while (carry) {
+      digits.unshift(carry)
+      carry = (digits[0] / BASE) | 0
+      digits[0] %= BASE
+    }
   }
 
   // deal with leading zeros
-  var j = 0
-  while (buffer[j] === 0) {
-    result[i] = ALPHABET_BUF[0]
-    j++
-    i--
-  }
+  for (i = 0; i < buffer.length - 1 && buffer[i] == 0; i++) digits.unshift(0)
 
-  return result.slice(i + 1, result.length).toString('ascii')
+  return digits.map(function(digit) { return ALPHABET[digit] }).join('')
 }
 
 function decode(string) {
   if (string.length === 0) return new Buffer(0)
 
-  var num = BigInteger.ZERO
+  var input = string.split('').map(function(c){
+    assert.notEqual(ALPHABET_MAP[c], undefined, 'Non-base58 character')
+    return ALPHABET_MAP[c]
+  })
 
-  for (var i = 0; i < string.length; i++) {
-    num = num.multiply(BASE)
+  var i, j, bytes = [0]
+  for (i = 0; i < input.length; i++) {
+    for (j = 0; j < bytes.length; j++) bytes[j] *= BASE
+    bytes[bytes.length - 1] += input[i]
 
-    var figure = ALPHABET_MAP[string.charAt(i)]
-    assert.notEqual(figure, undefined, 'Non-base58 character')
+    var carry = 0
+    for (j = bytes.length - 1; j >= 0; j--){
+      bytes[j] += carry
+      carry = bytes[j] >> 8
+      bytes[j] &= 0xff
+    }
 
-    num = num.add(figure)
+    while (carry) {
+      bytes.unshift(carry)
+      carry = bytes[0] >> 8
+      bytes[0] &= 0xff
+    }
   }
 
   // deal with leading zeros
-  var j = 0
-  while ((j < string.length) && (string[j] === ALPHABET[0])) {
-    j++
-  }
+  for (i = 0; i < input.length - 1 && input[i] == 0; i++) bytes.unshift(0)
 
-  var buffer = num.toBuffer()
-  var leadingZeros = new Buffer(j)
-  leadingZeros.fill(0)
-
-  return Buffer.concat([leadingZeros, buffer])
+  return new Buffer(bytes)
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "type": "git"
   },
   "main": "./lib/bs58.js",
-  "dependencies": {
-    "bigi": "^1.1.0"
-  },
   "scripts": {
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --reporter list test/*.js",
     "coveralls": "npm run-script coverage && node ./node_modules/.bin/coveralls < coverage/lcov.info",


### PR DESCRIPTION
Replace `bigi` with pure js.
Optimize byte operations with bitwise shifts.

Implements #2.
