### PR TITLE
Array operations optimization

### DIFF
--- a/lib/bs58.js
+++ b/lib/bs58.js
@@ -32,10 +32,9 @@ function encode(buffer) {
     }
 
     while (carry) {
-      digits.push(carry)
+      digits.push(carry % BASE)
 
-      carry = (digits[digits.length - 1] / BASE) | 0
-      digits[digits.length - 1] %= BASE
+      carry = (carry / BASE) | 0
     }
   }
 
@@ -67,10 +66,9 @@ function decode(string) {
     }
 
     while (carry) {
-      bytes.push(carry)
+      bytes.push(carry & 0xff)
 
-      carry = bytes[bytes.length - 1] >> 8
-      bytes[bytes.length - 1] &= 0xff
+      carry >>= 8
     }
   }
 


### PR DESCRIPTION
As demonstrated by http://jsperf.com/base58-array-ops, and even a basic understanding should make it clear, using `unshift` is much slower than using `push` in `Array` operations as each `unshift` is an O(n) operation.

This change just reverses the operation order on the array so as `push` becomes possible, with a single O(n) reversal done at the end of the function.
On Chrome, this gives a slight (~10-15%) improvement, but on Firefox 30 it gives up to a 50% improvement in ops/sec. 
