### PR TITLE
speed improvement for bs58.encode()

### DIFF
--- a/lib/bs58.js
+++ b/lib/bs58.js
@@ -39,7 +39,12 @@ function encode(buffer) {
   // deal with leading zeros
   for (i = 0; buffer[i] === 0 && i < buffer.length - 1; i++) digits.push(0)
 
-  return digits.reverse().map(function(digit) { return ALPHABET[digit] }).join('')
+  // convert digits to a string
+  var stringOutput = ""
+  for (var i = digits.length - 1; i >= 0; i--) {
+    stringOutput = stringOutput + ALPHABET[digits[i]]
+  }
+  return stringOutput
 }
 
 function decode(string) {


### PR DESCRIPTION
With this change, bs58.encode with 32-digit input runs in about 80% the time the previous version took.
