### PR TITLE
CHANGE: update for 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+4.0.0 / 2016-12-3
+------------------
+- `decode` now returns a `Buffer` again,  to avoid potential cryptographic errors. [Daniel Cousens / #21](https://github.com/cryptocoinjs/bs58/pull/21)
+
 3.0.0 / 2015-08-18
 ------------------
 - refactored module into generic [`base-x`](https://github.com/cryptocoinjs/base-x).


### PR DESCRIPTION
**Technically**,  this could be `1.3.0`.  Ha... 

https://github.com/cryptocoinjs/bs58/pull/9

I guess we had good intentions,  and `browserify` wasn't as prolific back then...