### PR TITLE
Update tests and documentation for v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ console.log(out) // => 16UjcYNBG9GTK4uq2f7yYEbuifqCzoLMGS
 
 ### decode(input)
 
-`input` must be a base 58 encoded string. Returns an `Array`.
+`input` must be a base 58 encoded string. Returns a [Buffer](https://nodejs.org/api/buffer.html).
 
 **example**:
 
@@ -43,11 +43,7 @@ var bs58 = require('bs58')
 
 var address = "16UjcYNBG9GTK4uq2f7yYEbuifqCzoLMGS"
 var out = bs58.decode(address)
-console.log(out.toString())
-// => 0,60,23,110,101,155,234,15,41,163,233,191,120,128,193,18,177,179,27,77,200,38,38,129,135
-
-// if using Node.js or browserify
-console.log(new Buffer(out).toString('hex'))
+console.log(out.toString('hex'))
 // => 003c176e659bea0f29a3e9bf7880c112b1b31b4dc826268187
 ```
 

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,7 @@ describe('base58', function () {
   describe('decode', function () {
     fixtures.valid.forEach(function (f) {
       it('can decode ' + f.string, function () {
-        var actual = new Buffer(base58.decode(f.string)).toString('hex')
+        var actual = base58.decode(f.string).toString('hex')
 
         assert.strictEqual(actual, f.hex)
       })


### PR DESCRIPTION
Since v4.0.0, `decode` returns a `Buffer`.