### PR TITLE
Files in package.json instead .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-.gitignore
-test/
-.DS_Store
-Makefile
-coverage/
-.min-wd
-.travis.yml

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "url": "https://github.com/cryptocoinjs/bs58",
     "type": "git"
   },
-  "main": "index.js",
+  "files": [
+    "./index.js"
+  ],
+  "main": "./index.js",
   "scripts": {
     "browser-test": "mochify --wd -R spec",
     "standard": "standard",


### PR DESCRIPTION
Usually such PR has big discussion what is better, but lets stay with `files` 😄 