### PR TITLE
Use const instead of var

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var basex = require('base-x')
-var ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+const basex = require('base-x')
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
 module.exports = basex(ALPHABET)

--- a/test/index.js
+++ b/test/index.js
@@ -1,13 +1,13 @@
-var test = require('tape')
-var base58 = require('../')
+const test = require('tape')
+const base58 = require('../')
 
-var fixtures = require('./fixtures.json')
+const fixtures = require('./fixtures.json')
 
 test('base58', function (t) {
   t.test('encode', function (t) {
     fixtures.valid.forEach(function (f) {
       t.test('can encode ' + f.hex, function (t) {
-        var actual = base58.encode(Buffer.from(f.hex, 'hex'))
+        const actual = base58.encode(Buffer.from(f.hex, 'hex'))
         t.equal(actual, f.string)
         t.end()
       })
@@ -19,7 +19,7 @@ test('base58', function (t) {
   t.test('decode', function (t) {
     fixtures.valid.forEach(function (f) {
       t.test('can decode ' + f.string, function (t) {
-        var actual = base58.decode(f.string).toString('hex')
+        const actual = base58.decode(f.string).toString('hex')
         t.same(actual, f.hex)
         t.end()
       })


### PR DESCRIPTION
Use `const` instead of `var` to conform to the [`no-var`](https://eslint.org/docs/rules/no-var) ESLint rule which is coming in a future version of [JavaScript Standard Style](https://standardjs.com). See https://github.com/standard/eslint-config-standard/pull/152.