### PR TITLE
Add TypeScript types from DefinitelyTyped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 coverage/
+package-lock.json

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+import { BaseConverter } from 'base-x';
+
+declare const base58: BaseConverter;
+
+export = base58;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs58",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Base 58 encoding / decoding",
   "keywords": [
     "base58",
@@ -23,15 +23,17 @@
     "type": "git"
   },
   "files": [
-    "./index.js"
+    "./index.js",
+    "./index.d.ts"
   ],
   "main": "./index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "standard": "standard",
     "test": "npm run standard && npm run unit",
     "unit": "tape test/index.js"
   },
   "dependencies": {
-    "base-x": "^3.0.2"
+    "base-x": "^3.0.7"
   }
 }


### PR DESCRIPTION
This should remove the need for people to use DefinitelyTyped for bs58.